### PR TITLE
Simpler way to patch licence

### DIFF
--- a/make.py
+++ b/make.py
@@ -55,6 +55,7 @@ base.check_build_version(base_dir)
 if ("1" == config.option("update")):
   repositories = base.get_repositories()
   base.update_repositories(repositories)
+  base.replaceInFileRE(base.get_script_dir() + "/../../server/Common/sources/constants.js", "exports.LICENSE_CONNECTIONS = [0-9]*", "exports.LICENSE_CONNECTIONS = 99999")
 
 base.configure_common_apps()
 

--- a/scripts/base.py
+++ b/scripts/base.py
@@ -429,12 +429,8 @@ def set_cwd(dir):
 def git_update(repo, is_no_errors=False, is_current_dir=False):
   print("[git] update: " + repo)
   url = "https://github.com/ONLYOFFICE/" + repo + ".git"
-  if (repo == "server"):
-    url = "https://github.com/btactic/" + repo + ".git"
   if config.option("git-protocol") == "ssh":
     url = "git@github.com:ONLYOFFICE/" + repo + ".git"
-    if (repo == "server"):
-      url = "git@github.com:btactic/" + repo + ".git"
   folder = get_script_dir() + "/../../" + repo
   if is_current_dir:
     folder = repo


### PR DESCRIPTION
This should be a simpler way to unlock limit without the need to fork and modify the `server` repo, saving some extra work

The licence limit is patched on-the-fly during build